### PR TITLE
add `#relations` lookup method to resource

### DIFF
--- a/lib/halibut/core/resource.rb
+++ b/lib/halibut/core/resource.rb
@@ -128,6 +128,23 @@ module Halibut::Core
       @embedded.add relation, resource
     end
 
+
+    # @return [Array] the set of resources, or links to them, with
+    # which the current resource has specified relationship.
+    #
+    #     resource = Halibut::Core::Resource.new
+    #     member2 =  Halibut::Core::Resource.new "http://example.com/2"
+    #
+    #     resource.add_link :item, "http://example.com/1
+    #     resource.embed_resource :item, member2
+    #     resource.relations :item
+    #     # => [#<Link("http://example.com/1")>, #<Resource("http://example.com/2")>]
+    #
+    # @param [String] relation relation
+    def relations(relation)
+      Array(links[relation]) + Array(embedded[relation])
+    end
+
     # Hash representation of the resource.
     # Will ommit links and embedded keys if they're empty
     #

--- a/spec/core/resource_spec.rb
+++ b/spec/core/resource_spec.rb
@@ -50,6 +50,14 @@ describe Halibut::Core::Resource do
       subject.links['lol'].first.href.must_equal normal_uri
     end
 
+    it "are retrievable as relations" do 
+      subject.add_link 'users', "http://example.com/1"
+      subject.add_link 'users', "http://example.com/2"
+
+      subject.relations('users').map(&:href).must_include "http://example.com/1"
+      subject.relations('users').map(&:href).must_include "http://example.com/2"
+    end
+
   end
 
   describe "Namespaces" do
@@ -97,6 +105,14 @@ describe Halibut::Core::Resource do
 
       subject.embedded['users'].first.must_equal res1
       subject.embedded['users'].last.must_equal  res2
+    end
+
+    it "are retrievable as relations" do 
+      subject.embed_resource 'users', res1
+      subject.embed_resource 'users', res2
+
+      subject.relations('users').must_include res1
+      subject.relations('users').must_include res2
     end
   end
 


### PR DESCRIPTION
Allows the client to care less about whether the relationship was
rendered as an embedded or a link
